### PR TITLE
fix(yaml):Cron job not formatted correctly

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -2,8 +2,8 @@ name: Auto-generate CHANGELOG
 on:
   release:
     types: [created, edited]
-    schedule:
-      - cron: "0 2 * * *"
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
update-changelog.yaml had incorrectly formated cron job, ie indented to far.
The cron job had been indented so it fell under another job.

closes #33