### PR TITLE
fix(log):CHANGELOG now updates on push #60

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -4,6 +4,9 @@ on:
     types: [created, edited]
   schedule:
     - cron: "0 23 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
* A copy-paste error seems to be the cause of removing the on push schedule.


closes #60