### PR TITLE
WIP(log):Comment out second BobAnkh job to test #93

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -23,10 +23,10 @@ jobs:
           PATH: "/CHANGELOG.md"
           COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:repo"
           TYPE: "chore:Chore,feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests, WIP:In Progress"
-      - uses: BobAnkh/auto-generate-changelog@master
-        with:
-          REPO_NAME: "imAsparky/junction-box"
-          ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PATH: "/docs/source/CHANGELOG.md"
-          COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:docs"
-          TYPE: "feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests"
+      # - uses: BobAnkh/auto-generate-changelog@master
+      #   with:
+      #     REPO_NAME: "imAsparky/junction-box"
+      #     ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      #     PATH: "/docs/source/CHANGELOG.md"
+      #     COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:docs"
+      #     TYPE: "feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests"


### PR DESCRIPTION
For a test, I have commented out the second job that updates the change log in
the documents.  If it works, split this job into two and have the second job run
before a readthedocs document build so that the changelog is up to date.

WIP #93