### PR TITLE
fix(log)Split changelog update now 2 files #93

### DIFF
--- a/.github/workflows/update-changelog-DOCS.yaml
+++ b/.github/workflows/update-changelog-DOCS.yaml
@@ -1,0 +1,26 @@
+name: Auto-generate CHANGELOG-DOCS
+on:
+  # release:
+  #   types: [created, edited]
+  schedule:
+    - cron: "0 23 * * *"
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: BobAnkh/auto-generate-changelog@master
+        with:
+          REPO_NAME: "imAsparky/junction-box"
+          ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PATH: "/docs/source/CHANGELOG.md"
+          COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:docs"
+          TYPE: "feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests"

--- a/.github/workflows/update-changelog-WIP.yaml
+++ b/.github/workflows/update-changelog-WIP.yaml
@@ -1,9 +1,9 @@
-name: Auto-generate CHANGELOG
+name: Auto-generate CHANGELOG-WIP
 on:
-  release:
-    types: [created, edited]
-  schedule:
-    - cron: "0 23 * * *"
+  # release:
+  #   types: [created, edited]
+  # # schedule:
+  #   - cron: "0 23 * * *"
   # push:
   #   branches:
   #     - main
@@ -23,10 +23,3 @@ jobs:
           PATH: "/CHANGELOG.md"
           COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:repo"
           TYPE: "chore:Chore,feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests, WIP:In Progress"
-      # - uses: BobAnkh/auto-generate-changelog@master
-      #   with:
-      #     REPO_NAME: "imAsparky/junction-box"
-      #     ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      #     PATH: "/docs/source/CHANGELOG.md"
-      #     COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:docs"
-      #     TYPE: "feat:Feature,fix:Bug Fixes,docs:Documentation,perf:Performance Improvements,refactor:Refactor,style:Styling,test:Tests"


### PR DESCRIPTION
Created a second git hub yaml action as a copy of the original and modified both.
New file: Auto-generate CHANGELOG-DOCS triggers On schedule @ 2300 UTC and manually.
Renamed to: Auto-generate CHANGELOG-WIP triggers only manually for now.

closes #92