### PR TITLE
fix(git):Fix typo in .git-commit-template.txt

### DIFF
--- a/.github/.git-commit-template.txt
+++ b/.github/.git-commit-template.txt
@@ -18,7 +18,7 @@
 # **   chore    (a chore that needs to be done)
 #      dbg      (changes in debugging code/frameworks; no production code change)
 #      defaults (changes default options)
-# **   doc      (changes to documentation)
+# **   docs      (changes to documentation)
 # **   feat     (new feature)
 # **   fix      (bug fix)
 #      hack     (temporary fix to make things move forward; please avoid it)


### PR DESCRIPTION
The list of tags at the bottom had doc, and should be docs