### PR TITLE
docs(style):Updated .git-commit-template.txt

### DIFF
--- a/docs/source/Style/style-developer.rst
+++ b/docs/source/Style/style-developer.rst
@@ -47,7 +47,7 @@ The git commit message follows the
     # **   chore    (a chore that needs to be done)
     #      dbg      (changes in debugging code/frameworks; no production code change)
     #      defaults (changes default options)
-    # **   doc      (changes to documentation)
+    # **   docs     (changes to documentation)
     # **   feat     (new feature)
     # **   fix      (bug fix)
     #      hack     (temporary fix to make things move forward; please avoid it)


### PR DESCRIPTION
I have updated the style guide code block to reflect the correction of a typo
in the git commit message template