### PR TITLE
feat(discussion):Links to discussion board #118

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@ A junction box is a place for making connections.
 
 |
 
+Would you mind providing feedback or creating a discussion on our GitHub
+`discussion board <https://github.com/imAsparky/junction-box/discussions>`__?
+
+|
+
 Junction Box documentation `here <https://junction-box.readthedocs.io/>`__.
 
 |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,23 +10,33 @@
    :align: center
 
 |
+|
 
 Welcome to Junction Box's documentation!
 ========================================
 :emph:`A place to document connections between technologies for our software development framework.`
+
+|
+|
 
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
 
-   Design/design-index
    Diataxis/diataxis-index
+   Design/design-index
    Style/style-index
    about
    CHANGELOG.md
 
+|
+|
 
+Would you mind providing feedback or creating a discussion on our GitHub
+`discussion board <https://github.com/imAsparky/junction-box/discussions>`__?
+
+|
 
 Indices and tables
 ==================


### PR DESCRIPTION
Add a link to the discussion board for people to discuss the project
on README and the documentation index.

closes #118