### PR TITLE
fix(sphinx): spinx-inline-tabs broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,8 +60,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 Sphinx==4.0.3
 sphinx-copybutton==0.4.0
-sphinx-inline-tabs>=2021.4.11b8
-sphinx-rtd-theme==0.5.2
+sphinx-inline-tabs
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0


### PR DESCRIPTION
Removed pinning version requirement of sphinx-inline-tabs
because readthedocs build is failing