### PR TITLE
chore(file):Fix python version for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
readthedocs does not support py3.9, so back to py3.8