### PR TITLE
chore(files):Pinned sphinx-inline-==2021.4.11b9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ snowballstemmer==2.1.0
 soupsieve==2.2.1
 Sphinx==4.0.3
 sphinx-copybutton==0.4.0
-sphinx-inline-tabs
+sphinx-inline-==2021.4.11b9
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0


### PR DESCRIPTION
Version pinned. readthedocs yaml with py3.8 as minimum
so expecting readthedocs to build correctly.