### PR TITLE
fix(pyup): Exclude autoclasstoc from checks #210

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-autoclasstoc @ git+git://github.com/imAsparky/autoclasstoc.git@6517d2b6158b2967163b2114fc1b6eb3586b9fde
+autoclasstoc @ git+git://github.com/imAsparky/autoclasstoc.git@6517d2b6158b2967163b2114fc1b6eb3586b9fde  # pyup: ignore
 furo==2021.10.9
 myst-parser==0.15.2
 Sphinx==4.2.0


### PR DESCRIPTION
Autoclasstoc does not run on Python 3.9.  I have submitted a pull
request to update autoclasstoc.
This will stop pyup pull requests for autoclasstoc.

closes #210